### PR TITLE
Hotfix/33 points

### DIFF
--- a/join/services/points.py
+++ b/join/services/points.py
@@ -1,15 +1,25 @@
+from rest_framework import exceptions, status
 from django.db import transaction
 from django.db.models import Sum
 from join.models import PointRecord
+from users.models import User
+
+class InsufficientPointError(exceptions.APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "보유 포인트가 부족합니다."
+    default_code = "insufficient_points"
 
 class PointService:
     @classmethod
     @transaction.atomic
     def add(cls, user, amount: int, msg: str) -> PointRecord:
-        bal = cls.get_balance(user) + amount
+        user_locked = User.objects.select_for_update().get(pk=user.pk)
+        bal = cls.get_balance(user_locked) + amount
         if bal < 0:
-            raise ValueError("포인트 부족")
-        return PointRecord.objects.create(user=user, amount=amount, balance=bal, type=msg)
+            raise InsufficientPointError()
+        user_locked.points = bal
+        user_locked.save(update_fields=["points"])
+        return PointRecord.objects.create(user=user_locked, amount=amount, balance=bal, type=msg)
 
     @staticmethod
     def get_balance(user) -> int:


### PR DESCRIPTION
- #33 
- PointService 클래스의 add 메소드를 사용하여 PointRecord(포인트 적립/사용) 추가시에 User의 points 필드 자동 업데이트되도록 구현
- 동시성 문제를 예방하고 트랜젝션 내에서 처리할 수 있도록 구현함
- 비용이 부족할 경우 "보유 포인트가 부족합니다." 메시지를 담은 예외 반환