### PR TITLE
fix: 원본 이미지 직접 업로드

### DIFF
--- a/join/services/s3.py
+++ b/join/services/s3.py
@@ -83,3 +83,12 @@ class S3Service:
             Params={"Bucket": settings.AWS_S3_STORAGE_BUCKET_NAME, "Key": key},
             ExpiresIn=expires,
         )
+
+    @classmethod
+    def upload_original_fileobj(cls, fileobj, key: str, content_type: str = "image/jpeg"):
+        cls._get_client().upload_fileobj(
+            fileobj,
+            settings.AWS_S3_STORAGE_BUCKET_NAME,
+            key,
+            ExtraArgs={"ContentType": content_type},
+        )

--- a/join/services/s3.py
+++ b/join/services/s3.py
@@ -85,7 +85,7 @@ class S3Service:
         )
 
     @classmethod
-    def upload_original_fileobj(cls, fileobj, key: str, content_type: str = "image/jpeg"):
+    def upload_original_fileobj(cls, fileobj, key: str, content_type: str = "image/png"):
         cls._get_client().upload_fileobj(
             fileobj,
             settings.AWS_S3_STORAGE_BUCKET_NAME,

--- a/market/views.py
+++ b/market/views.py
@@ -11,8 +11,6 @@ from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAdminUser
 from join.utils import build_image_key
 import uuid
-import boto3
-from django.conf import settings
 
 
 """
@@ -114,20 +112,7 @@ class ItemImageUploadView(APIView):
         ext = img_file.name.split(".")[-1]
         key = f"market-items/{uuid.uuid4()}.{ext}"
 
-        # 원본 이미지 직접 업로드
-        s3 = boto3.client(
-            "s3",
-            aws_access_key_id=settings.AWS_S3_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_S3_SECRET_ACCESS_KEY,
-            region_name=settings.AWS_S3_REGION,
-        )
-
-        s3.upload_fileobj(
-            img_file,
-            settings.AWS_S3_STORAGE_BUCKET_NAME,
-            key,
-            ExtraArgs={"ContentType": img_file.content_type},
-        )
+        S3Service.upload_original_fileobj(img_file, key, content_type=img_file.content_type)
 
         item.image_key = key
         item.save(update_fields=["image_key"])


### PR DESCRIPTION
close #73 
- 아이템 이미지 업로드는 관리자용 토큰으로만 가능
- 스티커 아이템은 사용자가 다운받아 사용해야 하기 때문에 리사이즈 없이 원본 이미지를 올리도록 수정