### PR TITLE
fix: view response에서 status 삭제

### DIFF
--- a/ranking/views.py
+++ b/ranking/views.py
@@ -135,7 +135,7 @@ class RankUserSharedCardView(APIView):
         return paginator.get_paginated_response({
             "rank": rank, 
             "username": username,
-            "sharedcards": serializer.data}, status=status.HTTP_200_OK)
+            "sharedcards": serializer.data})
     
 # 첫번째 유의사항
 class NotificationOneView(APIView):


### PR DESCRIPTION
## 수행
- 랭킹 내 공유 리스트 조회 api 뷰에서 response의 status 삭제(get_paginated_response()에서 이미 status 보내고 있음)

close #81 